### PR TITLE
mh| add validate template to avoid failing deployments due to syntax …

### DIFF
--- a/ec2/ci/pipeline.sh
+++ b/ec2/ci/pipeline.sh
@@ -16,6 +16,8 @@ REGION=${REGION:-"eu-central-1"}
 
 bundle check || bundle install
 
+aws cloudformation validate-template --template-body file://ec2/cf-templates/vpc.yaml
+
 # 1. Deploy vpc
 bundle exec autostacker24 update --template ec2/cf-templates/vpc.yaml \
     --params ec2/properties/vpc.yaml \
@@ -24,6 +26,7 @@ bundle exec autostacker24 update --template ec2/cf-templates/vpc.yaml \
     --profile "${PROFILE}"
 
 # 2. Deploy debug security group
+#aws cloudformation validate-template --template-body file://ec2/cf-templates/vpc-debug-security-group.yaml
 #bundle exec autostacker24 update --template ec2/cf-templates/vpc-debug-security-group.yaml \
 #    --stack "vpc-${TEAM_NAME}-debug-sg" \
 #    --param VPCStackName="vpc-${TEAM_NAME}" \
@@ -32,6 +35,7 @@ bundle exec autostacker24 update --template ec2/cf-templates/vpc.yaml \
 #    --profile "${PROFILE}"
 
 # 3. Deploy yocto
+#aws cloudformation validate-template --template-body file://ec2/cf-templates/vpc-yocto.yaml
 #bundle exec autostacker24 update --template ec2/cf-templates/vpc-yocto.yaml \
 #    --params ec2/properties/yocto.yaml \
 #    --stack "vpc-${TEAM_NAME}-yocto" \


### PR DESCRIPTION
Get a response before you try to rollout the template. It becomes a bit noisy on the shell, because the cloudformation validate-template command responses with a json where all structure (mostly parameters) and capabilites (iam). See: http://docs.aws.amazon.com/cli/latest/reference/cloudformation/validate-template.html 