### PR TITLE
Simplify code of terraform's non-4cheaters part

### DIFF
--- a/terraform/ec2/tf-files/main.tf
+++ b/terraform/ec2/tf-files/main.tf
@@ -2,5 +2,3 @@ provider "aws" {
   region = "${var.region}"
   profile = "${var.profile}"
 }
-
-data "aws_availability_zones" "current" {}

--- a/terraform/ec2/tf-files/variables.tf
+++ b/terraform/ec2/tf-files/variables.tf
@@ -4,12 +4,18 @@ variable "profile" {
 
 variable "region" {
   type = "string"
-  default = "eu-central-1"
+}
+
+variable "azs" {
+  type = "list"
 }
 
 variable "vpc_cidr" {
   type = "string"
-  default = "172.16.0.0/16"
+}
+
+variable "subnet_cidrs" {
+  type = "list"
 }
 
 variable "team_name" {

--- a/terraform/ec2/tf-files/vpc.tf
+++ b/terraform/ec2/tf-files/vpc.tf
@@ -7,13 +7,13 @@ resource "aws_vpc" "vpc" {
 }
 
 resource "aws_subnet" "publicsubnets" {
-  count = "${length(data.aws_availability_zones.current.names)}"
+  count = "${length(var.azs)}"
   cidr_block = "${cidrsubnet(aws_vpc.vpc.cidr_block, 5, count.index)}"
   vpc_id = "${aws_vpc.vpc.id}"
-  availability_zone = "${element(data.aws_availability_zones.current.names, count.index)}"
+  availability_zone = "${element(var.azs, count.index)}"
 
   tags {
-    Name = "${var.team_name}-${element(data.aws_availability_zones.current.names, count.index)}-sn"
+    Name = "${var.team_name}-${element(var.azs, count.index)}-sn"
   }
 }
 
@@ -43,7 +43,7 @@ resource "aws_route" "routepublic" {
 }
 
 resource "aws_route_table_association" "subnettopublic" {
-  count = "${length(data.aws_availability_zones.current.names)}"
+  count = "${length(var.azs)}"
   route_table_id = "${aws_route_table.routetable.id}"
   subnet_id = "${element(aws_subnet.publicsubnets.*.id, count.index)}"
 }


### PR DESCRIPTION
I tried to avoid using too much functions in the non-4cheaters part of terraform:

- Instead determining via `data "aws_availability_zones" "current" {}`, this is now done explicity by setting a variable.
- Subnets are not calculated using `cidrsubnet` but instead also set as variable.

Why? I think it might be confusing for people who never used terraform before. By removing the more advanced stuff, they can focus on the basic concepts of terraform. The more advanced now only lives in the 4cheaters part...